### PR TITLE
Add apache exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 Simple Ansible playbook to install the prometheus-stack.  
 The following componentes will be installed:  
 * node-exporter
+* apache-exporter
 * prometheus-server
 * grafana-server
 
 Pre-configured credentials:
 * Node Exporter
+  * Basic auth `prometheus-scraper` - `changeMe0815!`
+* Apache Exporter
   * Basic auth `prometheus-scraper` - `changeMe0815!`
 * Prometheus
   * Basic auth `prometheus` - `changeMe0815!`

--- a/group_vars/apache-exporter/apache-exporter.yml
+++ b/group_vars/apache-exporter/apache-exporter.yml
@@ -1,0 +1,6 @@
+---
+apache_exporter_tls_server_config:
+  cert_file: /etc/apache_exporter/tls/tls.cert
+  key_file: /etc/apache_exporter/tls/tls.pem
+apache_exporter_basic_auth_users:
+  prometheus-scraper: changeMe0815!

--- a/group_vars/apache-exporter/apache2.yml
+++ b/group_vars/apache-exporter/apache2.yml
@@ -1,0 +1,12 @@
+---
+apache_remove_default_vhost: true
+apache_create_vhosts: true
+apache_mods_enabled:
+  - status
+apache_vhosts:
+  - servername: "{{ ansible_fqdn}}"
+    extra_parameters: |
+      <Location /server-status>
+        SetHandler server-status
+        Require all granted
+      </Location>

--- a/group_vars/prometheus-server/prometheus.yml
+++ b/group_vars/prometheus-server/prometheus.yml
@@ -36,3 +36,14 @@ prometheus_scrape_configs:
     file_sd_configs:
       - files:
           - "/etc/prometheus/file_sd/node-exporters.yml"
+  - job_name: "apache_exporter"
+    metrics_path: "/metrics"
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+    basic_auth:
+      username: "prometheus-scraper"
+      password: "changeMe0815!"
+    static_configs:
+      - targets:
+          "{{ groups['apache-exporter'] | map('extract', hostvars, ['ansible_host']) | map('regex_replace', '$', ':9117') | list }}"

--- a/inventory
+++ b/inventory
@@ -6,9 +6,13 @@ prom-client-2   ansible_user=debian     ansible_host=prom-client-2
 [prometheus-server]
 prom-server     ansible_user=debian     ansible_host=prom-server
 
+[grafana-server]
+prom-server     ansible_user=debian     ansible_host=prom-server
+
 [node-exporter]
 prom-client-1   ansible_user=debian     ansible_host=prom-client-1
 prom-client-2   ansible_user=debian     ansible_host=prom-client-2
 
-[grafana-server]
-prom-server     ansible_user=debian     ansible_host=prom-server
+[apache-exporter]
+prom-client-1   ansible_user=debian     ansible_host=prom-client-1
+prom-client-2   ansible_user=debian     ansible_host=prom-client-2

--- a/main.yml
+++ b/main.yml
@@ -1,5 +1,6 @@
 ---
 - ansible.builtin.import_playbook: playbooks/hosts.yml
 - ansible.builtin.import_playbook: playbooks/node-exporter.yml
+- ansible.builtin.import_playbook: playbooks/apache-exporter.yml
 - ansible.builtin.import_playbook: playbooks/prometheus-server.yml
 - ansible.builtin.import_playbook: playbooks/grafana-server.yml

--- a/playbooks/apache-exporter.yml
+++ b/playbooks/apache-exporter.yml
@@ -1,0 +1,46 @@
+---
+- hosts: apache-exporter
+  become: true
+  pre_tasks:
+    - name: "Create system group {{ apache_exporter_system_group }}"
+      ansible.builtin.group:
+        name: "{{ apache_exporter_system_group }}"
+        system: true
+        state: present
+
+    - name: "Create system user {{ apache_exporter_system_user }}"
+      ansible.builtin.user:
+        name: "{{ apache_exporter_system_user }}"
+        system: true
+        shell: "/usr/sbin/nologin"
+        group: "{{ apache_exporter_system_group }}"
+        home: "{{ apache_exporter_config_dir }}"
+        create_home: false
+
+    - name: Create apache_exporter cert dir
+      ansible.builtin.file:
+        path: "/etc/apache_exporter/tls"
+        state: directory
+        owner: root
+        group: root
+
+    - name: Generate OpenSSL private key
+      community.crypto.openssl_privatekey:
+        path: /etc/apache_exporter/tls/tls.pem
+        size: 4096
+        owner: "{{ apache_exporter_system_user }}"
+        group: "{{ apache_exporter_system_group }}"
+        mode: '0640'
+
+    - name: Generate Self Signed OpenSSL certificate
+      community.crypto.x509_certificate:
+        path: /etc/apache_exporter/tls/tls.cert
+        privatekey_path: /etc/apache_exporter/tls/tls.pem
+        provider: selfsigned
+        owner: "{{ apache_exporter_system_user }}"
+        group: "{{ apache_exporter_system_group }}"
+        mode: '0640'
+
+  roles:
+    - geerlingguy.apache
+    - prometheus.prometheus.apache_exporter


### PR DESCRIPTION
* Installs apache2 & mod_status on nodes
* Installs apache_exporter
* Configure promtheus_scraper

Currently the apache_exporter role is not part of the prometheus collection.  
So this, PR depends on this https://github.com/prometheus-community/ansible/pull/527